### PR TITLE
Upgrade Hugo version to 0.148.2 in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.123.8'
+          hugo-version: '0.148.2'
           extended: true
 
       - name: Cache Hugo modules

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/nicolelaine/nicole-website
+module github/nicolelaine/nicolesiggins.com
 
-go 1.23.4
+go 1.24.2
 
-require github.com/jpanther/congo/v2 v2.11.0 // indirect
+require github.com/jpanther/congo/v2 v2.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/jpanther/congo/v2 v2.11.0 h1:whwuUIn20egAPfMR3HaFu7sW7/rz096bz26sgpsUAwk=
-github.com/jpanther/congo/v2 v2.11.0/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=
+github.com/jpanther/congo/v2 v2.12.2 h1:dr7oI/as+g+FJ6zVLZ3LSVOSRlsJjSsvTO6YP4zbOsQ=
+github.com/jpanther/congo/v2 v2.12.2/go.mod h1:1S7DRoO1ZYS4YUdFd1LjTkdyjQwsjFWd8TqSfz3Jd+M=


### PR DESCRIPTION
### Update Hugo version to v0.148.2 in GitHub Actions

This PR updates the GitHub Actions workflow to use Hugo v0.148.2 (extended version)  
to match the local development environment.

- Upgrades Hugo version in the workflow from v0.123.8 to v0.148.2
- Ensures theme (Congo v2.12.2) and Hugo versions are compatible
- Aims to prevent build errors related to shortcode/template incompatibility

Please review the build logs in the Actions tab after opening this PR to confirm the site builds successfully.

Once approved, merging this PR will update the live site build process.
